### PR TITLE
(SIMP-7458) Add AH and ESP Protocol Support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,2 +1,5 @@
+* Thu Jul 30 2020 Adam Yohrling <adam.yohrling@onyxpoint.com> - 0.1.1
+- Add support for ESP and AH protocol rules
+
 * Thu May 21 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.1.0
 - Initial module release

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -170,7 +170,7 @@ The networks/hosts to which the rule applies
 
 ##### `protocol`
 
-Data type: `Enum['icmp','tcp','udp','all']`
+Data type: `Enum['ah','esp','icmp','tcp','udp','all']`
 
 The network protocol to which the rule applies
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -75,14 +75,14 @@ class simp_firewalld (
   Array[Stdlib::Absolutepath]                          $tidy_dirs            = [
                                                                                  '/etc/firewalld/icmptypes',
                                                                                  '/etc/firewalld/ipsets',
-                                                                                 '/etc/firewalld/services'
+                                                                                 '/etc/firewalld/services',
                                                                                ],
   # lint:endignore
   String[1]                                            $tidy_prefix          = 'simp_',
   Integer[1]                                           $tidy_minutes         = 10,
   Array[Optional[String[1]]]                           $simp_zone_interfaces = [],
   Enum['default', 'ACCEPT', 'REJECT', 'DROP']          $simp_zone_target     = 'DROP',
-  String[1]                                            $package_ensure       = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' })
+  String[1]                                            $package_ensure       = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' }),
 ) {
   if $enable {
     Exec { path => '/usr/bin:/bin' }
@@ -95,7 +95,7 @@ class simp_firewalld (
       default_zone     => $default_zone,
       log_denied       => $log_denied,
       firewall_backend => $firewall_backend,
-      package_ensure   => $package_ensure
+      package_ensure   => $package_ensure,
     }
 
     unless $complete_reload {
@@ -110,7 +110,7 @@ class simp_firewalld (
       purge_ports      => true,
       interfaces       => $simp_zone_interfaces,
       target           => $simp_zone_target,
-      require          => Service['firewalld']
+      require          => Service['firewalld'],
     }
 
     if $default_zone == '99_simp' {
@@ -123,7 +123,7 @@ class simp_firewalld (
         backup  => false,
         matches => [$tidy_prefix],
         recurse => true,
-        type    => 'mtime'
+        type    => 'mtime',
       }
     }
   }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_firewalld",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "SIMP Team",
   "summary": "SIMP-oriented firewalld management",
   "license": "Apache-2.0",

--- a/spec/defines/rule/ah_esp_spec.rb
+++ b/spec/defines/rule/ah_esp_spec.rb
@@ -1,0 +1,105 @@
+require 'spec_helper.rb'
+
+describe "simp_firewalld::rule", :type => :define do
+  context  'supported operating systems' do
+    on_supported_os.each do |os, os_facts|
+      context "on #{os}" do
+        let(:facts) do
+          os_facts.merge({
+            :simplib__firewalls => ['iptables', 'firewalld']
+          })
+        end
+
+        let(:ipv4_nets) {
+          [
+            '10.0.2.0/24',
+            '10.0.2.33/32',
+            '1.2.3.4/32',
+            '2.3.4.0/24',
+            '3.0.0.0/8'
+          ]
+        }
+
+        let(:ipv6_nets) {
+          [
+            'fe80::/64',
+            '2001:cdba:0000:0000:0000:0000:3257:9652/128',
+            '2001:cdba:0000:0000:0000:0000:3257:9652/16'
+          ]
+        }
+
+        context "ah with trusted_nets in CIDR format" do
+          let( :title  ){ 'allow_ah' }
+          let( :params ){{
+            :protocol     => 'ah',
+            :trusted_nets => ipv4_nets + ipv6_nets,
+            :order        => 15
+          }}
+          it { is_expected.to create_simp_firewalld__rule(title) }
+
+          it {
+            is_expected.to create_firewalld_rich_rule("simp_15_#{title}_simp-sLxKcJ8Jr7GgDOF54KlBvQR2Yc").with(
+              {
+                :ensure     => 'present',
+                :family     => 'ipv4',
+                :source     => { 'ipset' => 'simp-sLxKcJ8Jr7GgDOF54KlBvQR2Yc' },
+                :action     => 'accept',
+                :zone       => '99_simp',
+                :protocol   => 'ah',
+              }
+            )
+          }
+
+          it {
+            is_expected.to create_firewalld_rich_rule("simp_15_#{title}_simp-l7zVcqWPK6oo3saymLCPHgjuhp").with(
+              {
+                :ensure     => 'present',
+                :family     => 'ipv6',
+                :source     => {'ipset' => 'simp-l7zVcqWPK6oo3saymLCPHgjuhp'},
+                :action     => 'accept',
+                :zone       => '99_simp',
+                :protocol   => 'ah',
+              }
+            )
+          }
+        end
+
+        context "esp with trusted_nets in CIDR format" do
+          let( :title  ){ 'allow_esp' }
+          let( :params ){{
+            :protocol     => 'esp',
+            :trusted_nets => ipv4_nets + ipv6_nets,
+            :order        => 15
+          }}
+          it { is_expected.to create_simp_firewalld__rule(title) }
+
+          it {
+            is_expected.to create_firewalld_rich_rule("simp_15_#{title}_simp-sLxKcJ8Jr7GgDOF54KlBvQR2Yc").with(
+              {
+                :ensure     => 'present',
+                :family     => 'ipv4',
+                :source     => { 'ipset' => 'simp-sLxKcJ8Jr7GgDOF54KlBvQR2Yc' },
+                :action     => 'accept',
+                :zone       => '99_simp',
+                :protocol   => 'esp',
+              }
+            )
+          }
+
+          it {
+            is_expected.to create_firewalld_rich_rule("simp_15_#{title}_simp-l7zVcqWPK6oo3saymLCPHgjuhp").with(
+              {
+                :ensure     => 'present',
+                :family     => 'ipv6',
+                :source     => {'ipset' => 'simp-l7zVcqWPK6oo3saymLCPHgjuhp'},
+                :action     => 'accept',
+                :zone       => '99_simp',
+                :protocol   => 'esp',
+              }
+            )
+          }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change adds the ability to add rich-rules for AH and ESP protocol
support. This is required for ability to utilize the libreswan module
for IPSec tunnels.

SIMP-7458 #comment firewalld support for necessary protocols