### PR TITLE
(SIMP-10169) simp_firewalld Add Puppet 7 acceptance test

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,9 +1,7 @@
 ---
 fixtures:
   repositories:
-    augeas_core:
-      repo: https://github.com/simp/pupmod-puppetlabs-augeas_core.git
-      puppet_version: ">= 6.0.0"
+    augeas_core: https://github.com/simp/pupmod-puppetlabs-augeas_core.git
     compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup.git
     firewalld: https://github.com/voxpupuli/puppet-firewalld.git
     simp_options: https://github.com/simp/pupmod-simp-simp_options.git

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -368,3 +368,9 @@ pup6.pe-oel-fips:
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,oel]'
+
+pup7.x:
+  <<: *pup_7_x
+  <<: *acceptance_base
+  script:
+    - 'bundle exec rake beaker:suites[default,default]'

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -20,6 +20,10 @@ RSpec.configure do |c|
   # ensure that environment OS is ready on each host
   fix_errata_on hosts
 
+  # Detect cases in which no examples are executed (e.g., nodeset does not
+  # have hosts with required roles)
+  c.fail_if_no_examples = true
+
   # Readable test descriptions
   c.formatter = :documentation
 


### PR DESCRIPTION
* Add a Puppet 7 acceptance test
* Remove check for Puppet >=6 in .fixtures.yml
* Fail acceptance tests if no examples are executed.

[SIMP-9666] #comment pupmod-simp-simp_firewalld acceptance tests configured
SIMP-10169 #close

[SIMP-9666]: https://simp-project.atlassian.net/browse/SIMP-9666