### PR TITLE
(SIMP-10258) Change firewalld backend to nftables for RHEL 8

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Tue Dec 21 2021 Kendall Moore <kendall@sicura.us> - 0.3.0
+- Changed default backend to nftables for RHEL 8
+
 * Wed Jun 16 2021 Chris Tessmer <chris.tessmer@onyxpoint.com> - 0.2.0
 - Removed support for Puppet 5
 - Ensured support for Puppet 7 in requirements and stdlib

--- a/data/os/RedHat-7.yaml
+++ b/data/os/RedHat-7.yaml
@@ -1,0 +1,2 @@
+---
+simp_firewalld::firewall_backend: 'iptables'

--- a/data/os/RedHat-8.0.yaml
+++ b/data/os/RedHat-8.0.yaml
@@ -1,0 +1,2 @@
+---
+simp_firewalld::firewall_backend: 'iptables'

--- a/data/os/RedHat-8.1.yaml
+++ b/data/os/RedHat-8.1.yaml
@@ -1,0 +1,2 @@
+---
+simp_firewalld::firewall_backend: 'iptables'

--- a/data/os/RedHat-8.yaml
+++ b/data/os/RedHat-8.yaml
@@ -1,0 +1,2 @@
+---
+simp_firewalld::firewall_backend: 'nftables'

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,16 @@
+---
+version: 5
+defaults:
+  datadir: data
+  data_hash: yaml_data
+hierarchy:
+  - name: "OS + Major.Minor Release"
+    path: "os/%{facts.os.family}-%{facts.os.release.major}.%{facts.os.release.minor}.yaml"
+  - name: "OS + Major Release"
+    path: "os/%{facts.os.family}-%{facts.os.release.major}.yaml"
+  - name: "OS"
+    path: "os/%{facts.os.name}.yaml"
+  - name: "OSFamily"
+    path: "os/%{facts.os.family}.yaml"
+  - name: "Common"
+    path: "common.yaml"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -71,7 +71,7 @@ class simp_firewalld (
   Boolean                                              $lockdown             = true,
   String[1]                                            $default_zone         = '99_simp',
   Enum['off', 'all','unicast','broadcast','multicast'] $log_denied           = 'unicast',
-  Enum['iptables','nftables']                          $firewall_backend     = 'iptables',
+  Enum['iptables','nftables']                          $firewall_backend,    # data in module
   Boolean                                              $enable_tidy          = true,
   # lint:ignore:2sp_soft_tabs
   Array[Stdlib::Absolutepath]                          $tidy_dirs            = [

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_firewalld",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": "SIMP Team",
   "summary": "SIMP-oriented firewalld management",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -44,12 +44,15 @@ describe 'simp_firewalld' do
               :simplib__firewalls => ['iptables', 'firewalld', 'nft']
             })
           end
+          let(:params) {{
+            :firewall_backend => 'nftables'
+          }}
 
           it { is_expected.to create_class('firewalld')
             .with_lockdown('yes')
             .with_default_zone('99_simp')
             .with_log_denied('unicast')
-            .with_firewall_backend('iptables')
+            .with_firewall_backend('nftables')
             .with_package_ensure('installed')
           }
         end


### PR DESCRIPTION
For RHEL 8.2 and newer the default backend will be nftables

[SIMP-10258] #close

[SIMP-10258]: https://simp-project.atlassian.net/browse/SIMP-10258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ