### PR TITLE
Support puppet-firewalld 5.0.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+* Mon Oct 02 2023 Steven Pritchard <steve@sicura.us> - 0.6.0
+- Use `firewalld_custom_service` instead of `firewalld::custom_service` for
+  compatibility with `puppet-firewalld` >= 5.0.0
+- Support stdlib 9
+- Support Puppet 8
+- Drop support for Puppet 6
+
 * Wed Aug 23 2023 Steven Pritchard <steve@sicura.us> - 0.5.0
 - Add AlmaLinux 8 support
 

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -103,10 +103,10 @@ define simp_firewalld::rule (
           }
         }
 
-        firewalld::custom_service { "${_prefix}${_safe_name}":
+        firewalld_custom_service { "${_prefix}${_safe_name}":
           short       => "${_prefix}${name}",
           description => "SIMP ${name}",
-          port        => $_dports,
+          ports       => $_dports,
           require     => Service['firewalld'],
         }
       }

--- a/metadata.json
+++ b/metadata.json
@@ -15,11 +15,11 @@
   "dependencies": [
     {
       "name": "puppet/firewalld",
-      "version_requirement": ">= 4.2.3 < 5.0.0"
+      "version_requirement": ">= 4.2.3 < 6.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 8.0.0 < 9.0.0"
+      "version_requirement": ">= 8.0.0 < 10.0.0"
     },
     {
       "name": "simp/simplib",
@@ -70,7 +70,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.22.1 < 8.0.0"
+      "version_requirement": ">= 7.0.0 < 9.0.0"
     }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_firewalld",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "author": "SIMP Team",
   "summary": "SIMP-oriented firewalld management",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Use `firewalld_custom_service` instead of `firewalld::custom_service` for compatibility with `puppet-firewalld` >= 5.0.0
- Support stdlib 9
- Support Puppet 8
- Drop support for Puppet 6